### PR TITLE
Add minor custom code (updating events and `state_manager` `set_state` expiration time)

### DIFF
--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -70,6 +70,38 @@ async def send_event_attachments_to_gundi(event_id: str, attachments: List[tuple
 
 
 @stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
+# TODO: ADD THIS TO THE TEMPLATE REPO!
+async def update_gundi_event(event: dict, **kwargs) -> dict:
+    """
+    Update an Event in Gundi using the REST API v2
+    :param event: An event in the following format:
+    {
+        "title": "Animal Sighting",
+        "event_type": "wildlife_sighting_rep",
+        "recorded_at":"2024-01-08 21:51:10-03:00",
+        "location":{
+            "lat":-51.688645,
+            "lon":-72.704421
+        },
+        "event_details":{
+            "site_name":"MM Spot",
+            "species":"lion"
+        }
+    }
+
+    :param kwargs: integration_id: The UUID of the related integration
+    :param kwargs: event_id: The UUID of the Gundi object_id to be updated
+    :return: A dict with the response from the API
+    """
+    integration_id = kwargs.get("integration_id")
+    assert integration_id, "integration_id is required"
+    event_id = kwargs.get("event_id")
+    assert event_id, "event_id is required"
+    sensors_api_client = await _get_sensors_api_client(integration_id=str(integration_id))
+    return await sensors_api_client.update_event(event_id=event_id, data=event)
+
+
+@stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
 async def send_observations_to_gundi(observations: List[dict], **kwargs) -> dict:
     """
     Send Observations to Gundi using the REST API v2

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -20,12 +20,14 @@ class IntegrationStateManager:
         value = json.loads(json_value) if json_value else {}
         return value
 
-    async def set_state(self, integration_id: str, action_id: str, state: dict, source_id: str = "no-source"):
+    # TODO: ADD THIS EXPIRE SUPPORT IN TEMPLATE REPO
+    async def set_state(self, integration_id: str, action_id: str, state: dict, source_id: str = "no-source", expire: int = None):
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 await self.db_client.set(
                     f"integration_state.{integration_id}.{action_id}.{source_id}",
-                    json.dumps(state, default=str)
+                    json.dumps(state, default=str),
+                    ex=expire
                 )
 
     async def delete_state(self, integration_id: str, action_id: str, source_id: str = "no-source"):

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -22,7 +22,8 @@ async def test_set_integration_state(mocker, mock_redis, integration_v2):
 
     mock_redis.Redis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source",
-        '{"last_execution": "' + execution_timestamp + '"}'
+        '{"last_execution": "' + execution_timestamp + '"}',
+        ex=None
     )
 
 
@@ -64,7 +65,8 @@ async def test_delete_integration_state(mocker, mock_redis, integration_v2):
 
     mock_redis.Redis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source",
-        '{"last_execution": "' + execution_timestamp + '"}'
+        '{"last_execution": "' + execution_timestamp + '"}',
+        ex=None
     )
 
     # then delete the state
@@ -96,7 +98,8 @@ async def test_set_source_state(mocker, mock_redis, integration_v2, mock_integra
 
     mock_redis.Redis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}",
-        json.dumps(mock_integration_state, default=str)
+        json.dumps(mock_integration_state, default=str),
+        ex=None
     )
 
 
@@ -136,7 +139,8 @@ async def test_delete_state_source_state(mocker, mock_redis, integration_v2, moc
 
     mock_redis.Redis.return_value.set.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}",
-        json.dumps(mock_integration_state, default=str)
+        json.dumps(mock_integration_state, default=str),
+        ex=None
     )
 
     # delete state


### PR DESCRIPTION
### NOTE: This support is required for current Skylight integration to work properly. There are TODOs in the code to remind the team to add that support in the template repo.


This pull request introduces two new functionalities to the `app/services/gundi.py` and `app/services/state.py` files. The changes include adding a new method to update events in Gundi and extending the state management functionality to support expiration times.

New functionalities:

* [`app/services/gundi.py`](diffhunk://#diff-26f049ecb523ee29a423a1f5eb64d12257198bba9c8b7872f4161c29b46e5b32R72-R103): Added a new asynchronous function `update_gundi_event` to update an event in Gundi using the REST API v2. This function includes retry logic for handling HTTP errors and requires `integration_id` and `event_id` as parameters.

State management enhancements:

* [`app/services/state.py`](diffhunk://#diff-82e2152ea754688cadb39a5a97ad11e8543391c11258cc974dc5d4b4d4833fe4L23-R30): Modified the `set_state` method to support an optional `expire` parameter, allowing the state to have an expiration time. This change also includes retry logic for Redis errors.