### PR TITLE
Log activity on attachments posting error and continue

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -286,12 +286,15 @@ async def process_attachments(transformed_data, response, integration):
                 "integration_id": str(integration.id),
                 "attention_needed": True
             })
+            log_data = {"message": message}
+            if server_response := getattr(e, "response", None):
+                log_data["server_response_body"] = server_response.text
             await log_activity(
                 integration_id=integration.id,
                 action_id="pull_events",
                 level=LogLevel.WARNING,
                 title=message,
-                data={"message": message}
+                data=log_data
             )
             continue
 


### PR DESCRIPTION
This pull request includes changes to `app/actions/handlers.py` to enhance logging and error handling during the processing of event attachments. 

The most important changes are:

Improvements to logging:

* Added import for `log_activity` from `app.services.activity_logger` and `LogLevel` from `gundi_core.schemas.v2` to support detailed logging.

Enhancements to error handling:

* Modified the error handling in `process_attachments` to include a detailed request object in the error message and log the activity with a warning level instead of raising the exception.


### Context

See https://github.com/PADAS/gundi-integration-inaturalist/pull/16

This approach works the same, so this change would fit here as well.