### PR TITLE
Catch 403 responses while reading attachments

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -18,7 +18,7 @@ from gql.transport.exceptions import TransportQueryError
 from gql.transport.httpx import HTTPXAsyncTransport, HTTPXTransport
 
 from gundi_core.events import LogLevel
-from app.services.activity_logger import log_activity
+from app.services.activity_logger import log_action_activity
 from app.services.errors import ConfigurationNotFound
 from app.services.utils import find_config_for_action
 from app.services.state import IntegrationStateManager
@@ -239,7 +239,7 @@ async def get_authentication_token(integration, auth, gql_client):
                 "attention_needed": True
             }
         )
-        await log_activity(
+        await log_action_activity(
             integration_id=integration.id,
             action_id="pull_events",
             level=LogLevel.ERROR,
@@ -468,7 +468,7 @@ async def get_skylight_events(integration, config_data, auth):
                     "attention_needed": True
                 }
             )
-            await log_activity(
+            await log_action_activity(
                 integration_id=integration.id,
                 action_id="pull_events",
                 level=LogLevel.WARNING,
@@ -486,7 +486,7 @@ async def get_skylight_events(integration, config_data, auth):
                     "attention_needed": True
                 }
             )
-            await log_activity(
+            await log_action_activity(
                 integration_id=integration.id,
                 action_id="pull_events",
                 level=LogLevel.WARNING,

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -17,8 +17,6 @@ from gql import Client as GQLClient, gql
 from gql.transport.exceptions import TransportQueryError
 from gql.transport.httpx import HTTPXAsyncTransport, HTTPXTransport
 
-from gundi_core.events import LogLevel
-from app.services.activity_logger import log_action_activity
 from app.services.errors import ConfigurationNotFound
 from app.services.utils import find_config_for_action
 from app.services.state import IntegrationStateManager
@@ -238,13 +236,6 @@ async def get_authentication_token(integration, auth, gql_client):
                 "integration_id": str(integration.id),
                 "attention_needed": True
             }
-        )
-        await log_action_activity(
-            integration_id=integration.id,
-            action_id="pull_events",
-            level=LogLevel.ERROR,
-            title="Error executing 'get_authentication_token' GraphQL query (TransportQueryError)",
-            data={"message": message}
         )
         raise te
 
@@ -468,13 +459,6 @@ async def get_skylight_events(integration, config_data, auth):
                     "attention_needed": True
                 }
             )
-            await log_action_activity(
-                integration_id=integration.id,
-                action_id="pull_events",
-                level=LogLevel.WARNING,
-                title="Error executing 'get_skylight_events' GraphQL query (TransportQueryError)",
-                data={"message": message}
-            )
             continue
         except Exception as e:
             message = f"Unhandled exception occurred. Exception: {e}"
@@ -485,13 +469,6 @@ async def get_skylight_events(integration, config_data, auth):
                     "integration_id": str(integration.id),
                     "attention_needed": True
                 }
-            )
-            await log_action_activity(
-                integration_id=integration.id,
-                action_id="pull_events",
-                level=LogLevel.WARNING,
-                title="Unhandled error while executing 'get_skylight_events' GraphQL query",
-                data={"message": message}
             )
             continue
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -186,7 +186,11 @@ async def action_pull_events(integration, action_config: PullEventsConfig):
 
         if events_to_patch:
             # Process events to patch
-            response = await patch_events(events_to_patch, updated_config_data, integration)
+            response = await patch_events(
+                events_to_patch,
+                [config.dict() for config in updated_config_data],
+                integration
+            )
             result["events_updated"] = len(response)
             result["details"]["updated"] = response
 


### PR DESCRIPTION
### Error to address

![image](https://github.com/user-attachments/assets/c9979ff9-56a3-4075-8f99-03308c0d89f9)

Sometimes, Skylight returns 403 while trying to read event attachments. The code is handling it in a general way but now the activity logs will show specific log content when a 403 response arrives.

---

This pull request includes updates to the logging mechanism across multiple functions and files in the project. 

The primary change is the replacement of the `log_activity` function with the `log_action_activity` function to improve logging specificity.

### Logging Mechanism Updates:
* [`app/actions/client.py`](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L21-R21): Replaced `log_activity` with `log_action_activity` in various functions to enhance logging specificity. [[1]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L21-R21) [[2]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L242-R242) [[3]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L471-R471) [[4]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L489-R489)
* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L15-R15): Replaced `log_activity` with `log_action_activity` and updated exception handling to provide more detailed error messages, particularly for HTTP 403 Forbidden responses. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L15-R15) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L279-R297)