### PR TITLE
GUNDI-4122: Vessel info response tweak

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -31,14 +31,14 @@ DEFAULT_SKYLIGHT_API_URL = 'https://api.skylight.earth/graphql'
 
 # For use in case an event doesn't have a vessel dict
 EMPTY_VESSEL_DICT = {
-    "vessel_0_category": "N/A",
-    "vessel_0_class": "N/A",
-    "vessel_0_country_filter": "N/A",
-    "vessel_0_display_country": "N/A",
-    "vessel_0_mmsi": "N/A",
-    "vessel_0_name": "N/A",
-    "vessel_0_subcategory": "N/A",
-    "vessel_0_type": "N/A",
+    "category": "N/A",
+    "class": "N/A",
+    "country_filter": "N/A",
+    "display_country": "N/A",
+    "mmsi": "N/A",
+    "name": "N/A",
+    "subcategory": "N/A",
+    "type": "N/A",
 }
 
 # Default mapping values (for ER destinations)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -70,7 +70,12 @@ def transform(config, data: dict) -> dict:
         # Get all available vessels info
         vessels = deepcopy(data.get("vessels", {}))
         if not vessels:
-            full_event_details.update(**client.EMPTY_VESSEL_DICT)
+            full_event_details.update(
+                {
+                    f"vessel_0_{key}": value
+                    for key, value in client.EMPTY_VESSEL_DICT.items()
+                }
+            )
         else:
             for vessel_name, vessel_detail in vessels.items():
                 if vessel_detail:
@@ -80,7 +85,7 @@ def transform(config, data: dict) -> dict:
                 else:
                     full_event_details.update(
                         {
-                            f"{vessel_name}_{key.split('_')[2]}": value
+                            f"{vessel_name}_{key}": value
                             for key, value in client.EMPTY_VESSEL_DICT.items()
                         }
                     )

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -73,9 +73,17 @@ def transform(config, data: dict) -> dict:
             full_event_details.update(**client.EMPTY_VESSEL_DICT)
         else:
             for vessel_name, vessel_detail in vessels.items():
-                for key, detail in vessel_detail.items():
-                    if detail is not None:
-                        full_event_details.update({vessel_name + "_" + key: detail})
+                if vessel_detail:
+                    for key, detail in vessel_detail.items():
+                        if detail is not None:
+                            full_event_details.update({vessel_name + "_" + key: detail})
+                else:
+                    full_event_details.update(
+                        {
+                            f"{vessel_name}_{key.split('_')[2]}": value
+                            for key, value in client.EMPTY_VESSEL_DICT.items()
+                        }
+                    )
 
         full_event_details["event_id"] = data.get("event_id")
         full_event_details["entry_link"] = settings.ENTRY_LINK_URL.format(

--- a/app/actions/tests/test_skylight.py
+++ b/app/actions/tests/test_skylight.py
@@ -220,7 +220,7 @@ def test_transform_with_empty_vessel_detail(skylight_client):
             "vessel_0": None
         }
     }
-    skylight_client.EMPTY_VESSEL_DICT = {"vessel_0_id": "N/A", "vessel_0_name": "N/A"}
+    skylight_client.EMPTY_VESSEL_DICT = {"id": "N/A", "name": "N/A"}
     config = [{"skylight_event_type": "some_event_type", "event_title": "Test Event", "event_type": "test_event"}]
     result = transform(config, data)
     assert result["event_details"]["vessel_0_id"] == "N/A"
@@ -239,7 +239,7 @@ def test_transform_without_vessel_info(skylight_client):
             'time': '2025-02-28T02:46:18.489582Z'
         }
     }
-    skylight_client.EMPTY_VESSEL_DICT = {"vessel_0_id": "N/A", "vessel_0_name": "N/A"}
+    skylight_client.EMPTY_VESSEL_DICT = {"id": "N/A", "name": "N/A"}
     config = [{"skylight_event_type": "some_event_type", "event_title": "Test Event", "event_type": "test_event"}]
     result = transform(config, data)
     assert result["event_details"]["vessel_0_id"] == "N/A"

--- a/app/actions/tests/test_skylight.py
+++ b/app/actions/tests/test_skylight.py
@@ -5,7 +5,7 @@ from gql.transport.exceptions import TransportQueryError
 
 from app.actions.client import execute_gql_query
 from app.actions.configurations import ProcessEventsPerAOIConfig
-from app.actions.handlers import action_pull_events, action_process_events_per_aoi, process_attachments
+from app.actions.handlers import action_pull_events, action_process_events_per_aoi, process_attachments, transform
 from app.services.state import IntegrationStateManager
 
 @pytest.fixture
@@ -23,6 +23,13 @@ def gql_client(mocker):
 @pytest.fixture
 def state_manager(mocker):
     return mocker.AsyncMock(IntegrationStateManager)
+
+
+@pytest.fixture
+def skylight_client():
+    import app.actions.client as client
+    return client
+
 
 @pytest.mark.asyncio
 async def test_execute_gql_query_success(mocker, gql_client, integration, auth):
@@ -172,3 +179,68 @@ async def test_process_attachments_403_error(mocker, integration):
 
     mock_read_img.assert_called_once_with("https://example.com/image.png")
     mock_log_action_activity.assert_called_once()
+
+def test_transform_with_vessel_info():
+    data = {
+        "event_type": "some_event_type",
+        "event_details": {},
+        "end": {
+            'point':
+                {
+                    'lat': 5.883240159715233,
+                    'lon': 115.69985442805672
+                },
+            'time': '2025-02-28T02:46:18.489582Z'
+        },
+        "vessels": {
+            "vessel1": {
+                "detail1": "value1",
+                "detail2": "value2"
+            }
+        }
+    }
+    config = [{"skylight_event_type": "some_event_type", "event_title": "Test Event", "event_type": "test_event"}]
+    result = transform(config, data)
+    assert result["event_details"]["vessel1_detail1"] == "value1"
+    assert result["event_details"]["vessel1_detail2"] == "value2"
+
+def test_transform_with_empty_vessel_detail(skylight_client):
+    data = {
+        "event_type": "some_event_type",
+        "event_details": {},
+        "end": {
+            'point':
+                {
+                    'lat': 5.883240159715233,
+                    'lon': 115.69985442805672
+                },
+            'time': '2025-02-28T02:46:18.489582Z'
+        },
+        "vessels": {
+            "vessel_0": None
+        }
+    }
+    skylight_client.EMPTY_VESSEL_DICT = {"vessel_0_id": "N/A", "vessel_0_name": "N/A"}
+    config = [{"skylight_event_type": "some_event_type", "event_title": "Test Event", "event_type": "test_event"}]
+    result = transform(config, data)
+    assert result["event_details"]["vessel_0_id"] == "N/A"
+    assert result["event_details"]["vessel_0_name"] == "N/A"
+
+def test_transform_without_vessel_info(skylight_client):
+    data = {
+        "event_type": "some_event_type",
+        "event_details": {},
+        "end": {
+            'point':
+                {
+                    'lat': 5.883240159715233,
+                    'lon': 115.69985442805672
+                },
+            'time': '2025-02-28T02:46:18.489582Z'
+        }
+    }
+    skylight_client.EMPTY_VESSEL_DICT = {"vessel_0_id": "N/A", "vessel_0_name": "N/A"}
+    config = [{"skylight_event_type": "some_event_type", "event_title": "Test Event", "event_type": "test_event"}]
+    result = transform(config, data)
+    assert result["event_details"]["vessel_0_id"] == "N/A"
+    assert result["event_details"]["vessel_0_name"] == "N/A"


### PR DESCRIPTION
### Relevant Link

https://allenai.atlassian.net/browse/GUNDI-4122

---

This pull request includes changes to the `app/actions` module, focusing on improving the handling of vessel information and adding new tests. The most important changes include modifying the `EMPTY_VESSEL_DICT` structure, updating the `transform` function to handle empty vessel details, and adding new test cases for the `transform` function.

Changes to handling of vessel information:

* [`app/actions/client.py`](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L34-R41): Simplified the `EMPTY_VESSEL_DICT` structure by removing the `vessel_0_` prefix from the keys.
* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L73-R91): Updated the `transform` function to dynamically add the `vessel_0_` prefix when updating `full_event_details` with values from `EMPTY_VESSEL_DICT`.

Addition of new tests:

* [`app/actions/tests/test_skylight.py`](diffhunk://#diff-3ed2c35be78f973247367eaac3acf1f149543effb62276f8a8f1d396d13e7dedL8-R8): Imported the `transform` function and added a new fixture for the `skylight_client`. [[1]](diffhunk://#diff-3ed2c35be78f973247367eaac3acf1f149543effb62276f8a8f1d396d13e7dedL8-R8) [[2]](diffhunk://#diff-3ed2c35be78f973247367eaac3acf1f149543effb62276f8a8f1d396d13e7dedR27-R33)
* [`app/actions/tests/test_skylight.py`](diffhunk://#diff-3ed2c35be78f973247367eaac3acf1f149543effb62276f8a8f1d396d13e7dedR182-R246): Added new test cases for the `transform` function to verify behavior with vessel information, empty vessel details, and without vessel information.