### PR TITLE
Remove `Alert` from event titles

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -45,37 +45,37 @@ EMPTY_VESSEL_DICT = {
 DEFAULT_EVENT_MAPPING = {
     "fishing_alert": {
         "event_type": "fishing_alert_rep",
-        "event_title": "Fishing Alert",
+        "event_title": "Fishing",
         "skylight_event_type": "fishing_activity_history"
     },
     "vessel_detection_alert": {
         "event_type": "detection_alert_rep",
-        "event_title": "Vessel Detection Alert",
+        "event_title": "Vessel Detection",
         "skylight_event_type": ["viirs", "sar_sentinel1", "eo_sentinel2"]
     },
     "speed_range_alert": {
         "event_type": "speed_range_alert_rep",
-        "event_title": "Speed Range Alert",
+        "event_title": "Speed Range",
         "skylight_event_type": "speed_range"
     },
     "marine_entry_alert": {
         "event_type": "entry_alert_rep",
-        "event_title": "Marine Entry Alert",
+        "event_title": "Marine Entry",
         "skylight_event_type": "aoi_visit"
     },
     "dark_activity_alert": {
         "event_type": "dark_activity_alert_rep",
-        "event_title": "Dark Activity Alert",
+        "event_title": "Dark Activity",
         "skylight_event_type": "dark_activity"
     },
     "dark_rendezvous_alert": {
         "event_type": "dark_rendezvous_alert_rep",
-        "event_title": "Dark Rendezvous Alert",
+        "event_title": "Dark Rendezvous",
         "skylight_event_type": "dark_rendezvous"
     },
     "standard_rendezvous_alert": {
         "event_type": "standard_rendezvous_alert_rep",
-        "event_title": "Standard Rendezvous Alert",
+        "event_title": "Standard Rendezvous",
         "skylight_event_type": "standard_rendezvous"
     }
 }

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -43,37 +43,37 @@ EMPTY_VESSEL_DICT = {
 
 # Default mapping values (for ER destinations)
 DEFAULT_EVENT_MAPPING = {
-    "fishing_alert": {
+    "fishing": {
         "event_type": "fishing_alert_rep",
         "event_title": "Fishing",
         "skylight_event_type": "fishing_activity_history"
     },
-    "vessel_detection_alert": {
+    "vessel_detection": {
         "event_type": "detection_alert_rep",
         "event_title": "Vessel Detection",
         "skylight_event_type": ["viirs", "sar_sentinel1", "eo_sentinel2"]
     },
-    "speed_range_alert": {
+    "speed_range": {
         "event_type": "speed_range_alert_rep",
         "event_title": "Speed Range",
         "skylight_event_type": "speed_range"
     },
-    "marine_entry_alert": {
+    "marine_entry": {
         "event_type": "entry_alert_rep",
         "event_title": "Marine Entry",
         "skylight_event_type": "aoi_visit"
     },
-    "dark_activity_alert": {
+    "dark_activity": {
         "event_type": "dark_activity_alert_rep",
         "event_title": "Dark Activity",
         "skylight_event_type": "dark_activity"
     },
-    "dark_rendezvous_alert": {
+    "dark_rendezvous": {
         "event_type": "dark_rendezvous_alert_rep",
         "event_title": "Dark Rendezvous",
         "skylight_event_type": "dark_rendezvous"
     },
-    "standard_rendezvous_alert": {
+    "standard_rendezvous": {
         "event_type": "standard_rendezvous_alert_rep",
         "event_title": "Standard Rendezvous",
         "skylight_event_type": "standard_rendezvous"


### PR DESCRIPTION
Relevant Link:

https://allenai.atlassian.net/browse/GUNDI-3969

---

This pull request includes changes to the `app/actions/client.py` file to simplify the event titles in the `DEFAULT_EVENT_MAPPING` dictionary.

The most important changes involve updating the `event_title` for various alert types to remove the word "Alert" from each title.

Simplification of event titles:

* [`app/actions/client.py`](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L48-R78): Updated the `event_title` for "fishing_alert" from "Fishing Alert" to "Fishing".
* [`app/actions/client.py`](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L48-R78): Updated the `event_title` for "vessel_detection_alert" from "Vessel Detection Alert" to "Vessel Detection".
* [`app/actions/client.py`](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L48-R78): Updated the `event_title` for "speed_range_alert" from "Speed Range Alert" to "Speed Range".
* [`app/actions/client.py`](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L48-R78): Updated the `event_title` for "marine_entry_alert" from "Marine Entry Alert" to "Marine Entry".
* [`app/actions/client.py`](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L48-R78): Updated the `event_title` for "dark_activity_alert" from "Dark Activity Alert" to "Dark Activity".

### How it looks in ER?

![image](https://github.com/user-attachments/assets/e70d8d74-810c-48d3-9087-d677d9b7d50f)
