### PR TITLE
GUNDI-4161: Add new event type for `Dark Vessel Detection` events

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -51,7 +51,7 @@ DEFAULT_EVENT_MAPPING = {
     "vessel_detection": {
         "event_type": "detection_alert_rep",
         "event_title": "Vessel Detection",
-        "skylight_event_type": ["viirs", "sar_sentinel1", "eo_sentinel2"]
+        "skylight_event_type": ["viirs", "sar_sentinel1", "eo_sentinel2", "eo_landsat_8_9"]
     },
     "speed_range": {
         "event_type": "speed_range_alert_rep",


### PR DESCRIPTION
### Relevant Link

https://allenai.atlassian.net/browse/GUNDI-4161

---

This pull request includes an update to the `app/actions/client.py` file to expand the types of events that can trigger a vessel detection alert.

* [`app/actions/client.py`](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L54-R54): Added "eo_landsat_8_9" to the `skylight_event_type` list for vessel detection alerts.