### PR TITLE
Chunk process_events_per_aoi payloads; stop retrying 4xx publishes

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,5 +1,6 @@
 import datetime
 import httpx
+import json
 import logging
 import stamina
 
@@ -25,6 +26,32 @@ logger = logging.getLogger(__name__)
 
 
 state_manager = IntegrationStateManager()
+
+# PubSub rejects publish requests over 10MB (400 Bad Request). The
+# RunIntegrationAction command message embeds the raw events plus config, and
+# PubSub base64-encodes message data (~33% overhead), so the events payload
+# per message must stay well under that limit.
+MAX_TRIGGER_PAYLOAD_BYTES = 2 * 1024 * 1024
+
+
+def batch_events_by_payload_size(events, max_payload_bytes):
+    # Splits events into ordered batches whose serialized size stays under
+    # max_payload_bytes. A single event larger than the limit gets its own
+    # batch (it can't be split further).
+    batches = []
+    current_batch = []
+    current_size = 0
+    for event in events:
+        event_size = len(json.dumps(event, default=str).encode("utf-8"))
+        if current_batch and current_size + event_size > max_payload_bytes:
+            batches.append(current_batch)
+            current_batch = []
+            current_size = 0
+        current_batch.append(event)
+        current_size += event_size
+    if current_batch:
+        batches.append(current_batch)
+    return batches
 
 
 def get_clean_event_id(event):
@@ -245,14 +272,15 @@ async def action_pull_events(integration, action_config: PullEventsConfig):
             if aoi_events:
                 result["events_extracted"] += len(aoi_events)
                 logger.info(f"Triggering 'process_events_per_aoi' action for AOI: '{aoi}' Events: '{len(aoi_events)}'")
-                parsed_config = ProcessEventsPerAOIConfig(
-                    integration_id=str(integration.id),
-                    aoi=aoi,
-                    events=aoi_events,
-                    updated_config_data=[config.dict() for config in updated_config_data]
-                )
-                await trigger_action(integration.id, "process_events_per_aoi", config=parsed_config)
-                result["process_events_per_aoi_action_triggered"] += 1
+                for events_batch in batch_events_by_payload_size(aoi_events, MAX_TRIGGER_PAYLOAD_BYTES):
+                    parsed_config = ProcessEventsPerAOIConfig(
+                        integration_id=str(integration.id),
+                        aoi=aoi,
+                        events=events_batch,
+                        updated_config_data=[config.dict() for config in updated_config_data]
+                    )
+                    await trigger_action(integration.id, "process_events_per_aoi", config=parsed_config)
+                    result["process_events_per_aoi_action_triggered"] += 1
                 logger.info(f"Triggered 'process_events_per_aoi' action for AOI: '{aoi}'")
 
         if events_to_patch:

--- a/app/actions/tests/test_skylight.py
+++ b/app/actions/tests/test_skylight.py
@@ -18,7 +18,13 @@ from app.actions.client import (
     _TOKEN_EXPIRY_SKEW_SECONDS,
 )
 from app.actions.configurations import ProcessEventsPerAOIConfig
-from app.actions.handlers import action_pull_events, action_process_events_per_aoi, process_attachments, transform
+from app.actions.handlers import (
+    action_pull_events,
+    action_process_events_per_aoi,
+    batch_events_by_payload_size,
+    process_attachments,
+    transform,
+)
 from app.services.state import IntegrationStateManager
 
 
@@ -521,6 +527,61 @@ async def test_action_pull_events_triggers_process_events_per_aoi(mocker, integr
             updated_config_data=[]
         )
     )
+
+
+def test_batch_events_by_payload_size_keeps_small_lists_in_one_batch():
+    events = [{"event_id": "event1"}, {"event_id": "event2"}]
+
+    assert batch_events_by_payload_size(events, max_payload_bytes=10_000) == [events]
+
+
+def test_batch_events_by_payload_size_splits_events_over_limit():
+    events = [{"event_id": f"event{i}", "data": "x" * 100} for i in range(5)]
+    event_size = len(json.dumps(events[0]).encode("utf-8"))
+
+    batches = batch_events_by_payload_size(events, max_payload_bytes=event_size * 2)
+
+    assert len(batches) == 3
+    assert all(len(batch) <= 2 for batch in batches)
+    assert [event for batch in batches for event in batch] == events
+
+
+def test_batch_events_by_payload_size_gives_oversized_event_its_own_batch():
+    events = [{"event_id": "event1", "data": "x" * 500}, {"event_id": "event2"}]
+
+    batches = batch_events_by_payload_size(events, max_payload_bytes=100)
+
+    assert batches == [[events[0]], [events[1]]]
+
+
+@pytest.mark.asyncio
+async def test_action_pull_events_splits_large_aoi_into_multiple_triggers(
+        mocker, integration, pull_events_config, mock_publish_event
+):
+    # A single PubSub command message embedding every event for an AOI can
+    # exceed PubSub's 10MB publish limit (400 Bad Request in production), so
+    # large AOIs must be dispatched as multiple bounded messages.
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+    events = [{"event_id": f"event{i}", "data": "x" * 200} for i in range(10)]
+    mocker.patch("app.actions.client.get_skylight_events", return_value=({"aoi": events}, []))
+    mocker.patch("app.actions.client.get_auth_config", return_value=None)
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", return_value=None)
+    mock_trigger_action = mocker.patch("app.actions.handlers.trigger_action", return_value=None)
+    mocker.patch("app.actions.handlers.MAX_TRIGGER_PAYLOAD_BYTES", 500)
+
+    result = await action_pull_events(integration, pull_events_config)
+
+    assert mock_trigger_action.call_count > 1
+    dispatched_events = []
+    for call in mock_trigger_action.call_args_list:
+        config = call.kwargs["config"]
+        assert config.aoi == "aoi"
+        dispatched_events.extend(config.events)
+    assert dispatched_events == events
+    assert result["events_extracted"] == 10
+    assert result["process_events_per_aoi_action_triggered"] == mock_trigger_action.call_count
 
 
 @pytest.mark.asyncio

--- a/app/services/activity_logger.py
+++ b/app/services/activity_logger.py
@@ -31,6 +31,23 @@ from app import settings
 logger = logging.getLogger(__name__)
 
 
+class _NonRetryablePublishError(Exception):
+    # Carries a non-retryable publish error (4xx other than 429) past stamina's
+    # retry, which can only match on exception type. publish_event unwraps it
+    # so callers still see the original exception.
+    def __init__(self, original: Exception):
+        super().__init__(str(original))
+        self.original = original
+
+
+def _is_non_retryable(e: Exception) -> bool:
+    return (
+        isinstance(e, aiohttp.ClientResponseError)
+        and 400 <= e.status < 500
+        and e.status != 429
+    )
+
+
 # Publish events for other services or system components
 @stamina.retry(
     on=(aiohttp.ClientError, asyncio.TimeoutError),
@@ -39,7 +56,7 @@ logger = logging.getLogger(__name__)
     wait_max=60,
     wait_jitter=5.0
 )
-async def publish_event(event: SystemEventBaseModel, topic_name: str):
+async def _publish_event_with_retries(event: SystemEventBaseModel, topic_name: str):
     timeout_settings = aiohttp.ClientTimeout(total=20.0)
     async with aiohttp.ClientSession(
         raise_for_status=True, timeout=timeout_settings
@@ -54,14 +71,29 @@ async def publish_event(event: SystemEventBaseModel, topic_name: str):
         try:  # Send to pubsub
             response = await client.publish(topic, messages)
         except Exception as e:
+            if _is_non_retryable(e):
+                logger.exception(
+                    f"Error publishing system event to topic {topic_name} "
+                    f"(payload size: {len(binary_payload)} bytes): {e}. "
+                    "Client errors are not retried."
+                )
+                raise _NonRetryablePublishError(e) from e
             logger.exception(
-                f"Error publishing system event to topic {topic_name}: {e}. This will be retried."
+                f"Error publishing system event to topic {topic_name} "
+                f"(payload size: {len(binary_payload)} bytes): {e}. This will be retried."
             )
             raise e
         else:
             logger.debug(f"System event {event} published successfully.")
             logger.debug(f"GCP PubSub response: {response}")
             return response
+
+
+async def publish_event(event: SystemEventBaseModel, topic_name: str):
+    try:
+        return await _publish_event_with_retries(event, topic_name)
+    except _NonRetryablePublishError as e:
+        raise e.original
 
 
 async def log_activity(integration_id: str, action_id: str, title: str, level="INFO", config_data: dict = None, data: dict = None):

--- a/app/services/tests/test_activity_logger.py
+++ b/app/services/tests/test_activity_logger.py
@@ -1,4 +1,6 @@
+import aiohttp
 import pytest
+from types import SimpleNamespace
 from unittest.mock import ANY
 from gundi_core.events import (
     LogLevel,
@@ -43,6 +45,77 @@ async def test_publish_event(
         f"projects/{settings.GCP_PROJECT_ID}/topics/{settings.INTEGRATION_EVENTS_TOPIC}",
         [integration_event_pubsub_message],
     )
+
+
+def _client_response_error(status, message):
+    request_info = SimpleNamespace(real_url="https://pubsub.googleapis.com/v1/topics/test:publish")
+    return aiohttp.ClientResponseError(
+        request_info=request_info, history=(), status=status, message=message
+    )
+
+
+@pytest.fixture
+def fast_retries(mocker):
+    # stamina instantiates tenacity.AsyncRetrying at call time (via
+    # stamina._core._t), and tenacity binds asyncio.sleep as its default
+    # sleep. Inject an instant sleep so retry waits don't slow tests down.
+    import stamina._core
+
+    real_async_retrying = stamina._core._t.AsyncRetrying
+
+    async def _instant_sleep(_delay, result=None):
+        return result
+
+    mocker.patch.object(
+        stamina._core._t,
+        "AsyncRetrying",
+        lambda **kwargs: real_async_retrying(sleep=_instant_sleep, **kwargs),
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_event_does_not_retry_client_errors(
+        mocker, mock_pubsub_client, action_started_event, fast_retries
+):
+    # A 4xx (e.g. an oversized message rejected with 400) will never succeed
+    # on retry, so publish_event must fail fast instead of burning 5 attempts.
+    mocker.patch("app.services.activity_logger.pubsub", mock_pubsub_client)
+    publish_mock = mock_pubsub_client.PublisherClient.return_value.publish
+    publish_mock.side_effect = _client_response_error(400, "Bad Request")
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await publish_event(
+            event=action_started_event,
+            topic_name=settings.INTEGRATION_EVENTS_TOPIC,
+        )
+
+    assert publish_mock.call_count == 1
+
+
+@pytest.mark.parametrize("status", [500, 503, 429])
+@pytest.mark.asyncio
+async def test_publish_event_retries_transient_errors(
+        mocker, mock_pubsub_client, gcp_pubsub_publish_response, action_started_event, fast_retries, status
+):
+    mocker.patch("app.services.activity_logger.pubsub", mock_pubsub_client)
+    publish_mock = mock_pubsub_client.PublisherClient.return_value.publish
+
+    async def _ok():
+        return gcp_pubsub_publish_response
+
+    publish_mock.side_effect = [
+        _client_response_error(status, "Transient error"),
+        _client_response_error(status, "Transient error"),
+        _ok(),
+    ]
+
+    response = await publish_event(
+        event=action_started_event,
+        topic_name=settings.INTEGRATION_EVENTS_TOPIC,
+    )
+
+    assert response == gcp_pubsub_publish_response
+    assert publish_mock.call_count == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Production (`skylight-actions-runner`, integration `829c1db8-368b-4851-a507-6132ddba9c61`) is failing every scheduled `pull_events` run with:

```
aiohttp.client_exceptions.ClientResponseError: 400, message='Bad Request',
url=URL('https://pubsub.googleapis.com/v1/projects/cdip-prod1-78ca/topics/skylight-actions-topic:publish')
```

`action_pull_events` embeds an AOI's **entire** events list in a single `RunIntegrationAction` PubSub command message. A busy AOI (pageSize 1000, 30-day initial window, ~1–2 KB per event, plus base64 inflation) exceeds PubSub's 10 MB publish limit, so the publish is rejected with a deterministic 400. Because the action fails before state advances, every run refetches the same growing window — it never self-heals, and events for that AOI are not delivered.

Two aggravating factors: `publish_event` retried the 400 five times (stamina retries all `aiohttp.ClientError`, including non-transient 4xx), and `raise_for_status=True` discards the response body, hiding the "payload size exceeds the limit" detail.

## Fix

- **Chunk the fan-out** (`app/actions/handlers.py`): new `batch_events_by_payload_size()` splits each AOI's events into ordered batches whose serialized size stays under `MAX_TRIGGER_PAYLOAD_BYTES` (2 MB — headroom for base64 overhead and the command envelope), and `action_pull_events` triggers one `process_events_per_aoi` per batch. Order preserved; an event larger than the limit gets its own batch. `action_process_events_per_aoi` needed no changes.
- **Fail fast on 4xx** (`app/services/activity_logger.py`): non-retryable client errors (4xx except 429) now raise immediately instead of burning 5 retry attempts. stamina 23.2 can only match on exception type, so they're routed past the retry via an internal wrapper that `publish_event` unwraps — callers still see the original `ClientResponseError`. 5xx/429/timeouts/connection errors retry exactly as before.
- **Log payload size** on every publish failure, so a future 400 is immediately diagnosable.

## Tests

- `batch_events_by_payload_size`: single batch when under limit, splits at the limit, oversized event isolated in its own batch
- `action_pull_events` dispatches a large AOI across multiple triggers with no events lost and accurate result counters
- `publish_event` raises after exactly one attempt on 400 (failed with `5 == 1` before the fix); 500/503/429 still retry (parametrized)
- Full suite: 101 passed (93 on main + 8 new)

## After deploy

Integration `829c1db8` should recover on its next scheduled run — the stuck cursor never advanced, so the backlog will now go out in bounded batches. If a 400 ever recurs, the new log line includes the payload size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)